### PR TITLE
Backported "Handle response header Transfer-Encoding: identity" commit from official GNOME repo

### DIFF
--- a/recipes-support/libsoup/libsoup-2.4/fix-identity-transfer-encoding-header.patch
+++ b/recipes-support/libsoup/libsoup-2.4/fix-identity-transfer-encoding-header.patch
@@ -1,0 +1,28 @@
+From a1148a0431079e4ae6b7a91e135a6aca6878014d Mon Sep 17 00:00:00 2001
+From: Thomas Bluemel <tbluemel@control4.com>
+Date: Thu, 27 Jun 2019 11:33:35 -0600
+Subject: [PATCH] Handle response header Transfer-Encoding: identity
+
+Don't set the encoding to SOUP_ENCODING_UNRECOGNIZED if the
+Transfer-Encoding value is "identity". This allows
+soup_message_headers_get_encoding to determine the encoding
+based on the other headers present (if any).
+
+Fixes #148
+---
+ libsoup/soup-message-headers.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libsoup/soup-message-headers.c b/libsoup/soup-message-headers.c
+index cdd4f1cf..4e41b031 100644
+--- a/libsoup/soup-message-headers.c
++++ b/libsoup/soup-message-headers.c
+@@ -591,7 +591,7 @@ transfer_encoding_setter (SoupMessageHeaders *hdrs, const char *value)
+ 	if (value) {
+ 		if (g_ascii_strcasecmp (value, "chunked") == 0)
+ 			hdrs->encoding = SOUP_ENCODING_CHUNKED;
+-		else
++		else if (g_ascii_strcasecmp (value, "identity") != 0)
+ 			hdrs->encoding = SOUP_ENCODING_UNRECOGNIZED;
+ 	} else
+ 		hdrs->encoding = -1;

--- a/recipes-support/libsoup/libsoup-2.4_2.40.2.bb
+++ b/recipes-support/libsoup/libsoup-2.4_2.40.2.bb
@@ -13,6 +13,7 @@ DEPENDS = "glib-2.0 gnutls libxml2 libproxy sqlite3 libgnome-keyring"
 
 SHRT_VER = "${@bb.data.getVar('PV',d,1).split('.')[0]}.${@bb.data.getVar('PV',d,1).split('.')[1]}"
 SRC_URI = "${GNOME_MIRROR}/libsoup/${SHRT_VER}/libsoup-${PV}.tar.xz"
+SRC_URI += "file://fix-identity-transfer-encoding-header.patch"
 
 SRC_URI[md5sum] = "211ec6b733d4de33056b56838c88436e"
 SRC_URI[sha256sum] = "32e81220f53abb1f5bbe7d8b0717119df70667fc48e2342d82209ed1593e71dc"


### PR DESCRIPTION
https://github.com/GNOME/libsoup/commit/a1148a0431079e4ae6b7a91e135a6aca6878014d#diff-a4e431a75b7a07ff702487d780207639

The purpose of adding this backport is to address issues with various TuneIn stations being unable to play since they send a "Transport-Encoding: identity" header. See:

https://nuvotechnologies.fogbugz.com/f/cases/55027/KOMO-News-on-TuneIn-returns-Unplayable-by-Nuvo-Player

https://nuvotechnologies.fogbugz.com/f/cases/68932/TuneIn-claims-that-format-is-not-compatible-KNKX-public-radio